### PR TITLE
Use metaData url in place of metaData JSON

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,19 @@ install:
 	python -m pip install --upgrade pip && \
 	python -m pip install -e .[dev]
 
-test:
+lint:
 	black --check altadb && \
 	flake8 --benchmark --count altadb && \
 	pycodestyle --benchmark --count --statistics altadb && \
 	pydocstyle --count altadb && \
 	mypy altadb && \
 	pylint --rcfile=setup.cfg -j=3 --recursive=y altadb
-	pytest -n 10 -x tests 
+
+unit:
+	pytest -n 12 -x tests
+
+test: lint unit
+
 
 build: clean install
 	python -m build -w -n -o .

--- a/altadb/__init__.py
+++ b/altadb/__init__.py
@@ -17,7 +17,7 @@ from altadb.utils.common_utils import config_migration
 from .config import config
 from .version_check import version_check
 
-__version__ = "0.0.5"
+__version__ = "0.0.6"
 
 # windows event loop close bug https://github.com/encode/httpx/issues/914#issuecomment-622586610
 try:

--- a/altadb/utils/files.py
+++ b/altadb/utils/files.py
@@ -453,11 +453,11 @@ async def save_dicom_series(
 
             tasks = []
             metadata_url = res_json["metaData"]
-            instances: Dict[str, Any] = {}
+            instances: List[Dict[str, Any]] = []
             async with aiosession.get(metadata_url) as response:
                 response.raise_for_status()
-                instances = await response.json()
-            for instance in instances["instances"]:
+                instances = (await response.json())["instances"]
+            for instance in instances:
                 frame_ids = [frame["id"] for frame in instance["frames"]]
                 image_frames_urls = [
                     frameid_url_map[frame_id] for frame_id in frame_ids

--- a/altadb/utils/files.py
+++ b/altadb/utils/files.py
@@ -452,7 +452,13 @@ async def save_dicom_series(
             }
 
             tasks = []
-            for instance in res_json["metaData"]["instances"]:
+            metadata_url = res_json["metaData"]
+            instances: Dict[str, Any] = {}
+            async with aiosession.get(metadata_url) as response:
+                response.raise_for_status()
+                instances = await response.json()
+            print("Instances", instances)
+            for instance in instances["instances"]:
                 frame_ids = [frame["id"] for frame in instance["frames"]]
                 image_frames_urls = [
                     frameid_url_map[frame_id] for frame_id in frame_ids

--- a/altadb/utils/files.py
+++ b/altadb/utils/files.py
@@ -457,7 +457,6 @@ async def save_dicom_series(
             async with aiosession.get(metadata_url) as response:
                 response.raise_for_status()
                 instances = await response.json()
-            print("Instances", instances)
             for instance in instances["instances"]:
                 frame_ids = [frame["id"] for frame in instance["frames"]]
                 image_frames_urls = [

--- a/tests/contstants.py
+++ b/tests/contstants.py
@@ -15,6 +15,7 @@ DATA_ITEMS = [
     "ModalityHC",
     "ModalityOT",
     "AbdominalMR",
+    "Tomo",
 ]
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -65,7 +65,13 @@ def build_sop_metadata_map_remote(
         headers=headers,
     )
     sop_instance_uid_metadata_map = {}
-    for item in response.json()["metaData"]["instances"]:
+    metadata_url = response.json()["metaData"]
+    response = requests.get(
+        metadata_url,
+        headers=headers,
+    )
+    instances = response.json()["instances"]
+    for item in instances:
         series_metadata = item["metaData"]
         sop_instance_uid_metadata_map[
             series_metadata[ExactHeadersComparison.SOPInstanceUID.value]["Value"][0]


### PR DESCRIPTION
Issue
-------------
For some files, AltaDB was not able to return the file metadata because of metadata size exceeding the payload limits.

Context
-------------
In a change, AltaDB was made to support files with large metadata by exposing a URL instead of the metadata.

Result
-------------
This change reflects the same on the SDK.
This change also introduces one such file to the test suite to make sure that exports for such files work.